### PR TITLE
utils: changed developer tag in appdata

### DIFF
--- a/utils/sugarapp-gen-appdata
+++ b/utils/sugarapp-gen-appdata
@@ -41,7 +41,8 @@ def generate_appdata(info_path, appdata_path):
         'description',
         'update_contact',
         'release_date',
-        'developer_name']
+        'developer_name',
+        'developer_id']
     for name in required_fields:
         if not info.has_option('Activity', name):
             print('[ERROR] Activity needs {} metadata for AppStream '
@@ -56,7 +57,9 @@ def generate_appdata(info_path, appdata_path):
         bundle_id
     ET.SubElement(root, 'update_contact').text = \
         info.get('Activity', 'update_contact')
-    ET.SubElement(root, 'developer_name').text = \
+    dev = ET.SubElement(root, 'developer',
+                        id=info.get('Activity', 'developer_id'))
+    ET.SubElement(dev, 'name').text = \
         info.get('Activity', 'developer_name')
     ET.SubElement(root, 'id').text = bundle_id
     ET.SubElement(root, 'launchable', type='desktop-id').text = \


### PR DESCRIPTION
This commit will use developer block in appdata/metainfo because `developer_name` element is deprecated now.
From now on  we will have to add a new field `developer_id` in activity.info.
Fixes  #14
